### PR TITLE
Call the function passed to Signal.foldp curried

### DIFF
--- a/src/Signal.purs
+++ b/src/Signal.purs
@@ -55,10 +55,10 @@ foreign import foldp
   "function foldp(fun) {\
   \  return function(seed) {\
   \    return function(sig) {\
-  \      var acc = fun(sig.get(), seed);\
+  \      var acc = fun(sig.get())(seed);\
   \      var out = constant(acc);\
   \      sig.subscribe(function(val) {\
-  \        acc = fun(val, acc);\
+  \        acc = fun(val)(acc);\
   \        out.set(acc);\
   \      });\
   \      return out;\


### PR DESCRIPTION
`Signal.foldp` calls the function passed in as a multiple-argument function. It will likely be passed a curried function, so should apply the arguments separately.
