### PR TITLE
Track latest version of purescript-timers

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "dependencies": {
     "purescript-dom": "~0.1.1",
-    "purescript-timers": "~0.0.5",
+    "purescript-timers": "~0.0.6",
     "purescript-refs": "~0.1.1"
   },
   "license": "Apache-2.0",

--- a/src/Signal/DOM.purs
+++ b/src/Signal/DOM.purs
@@ -10,7 +10,7 @@ module Signal.DOM
   ) where
 
 import Control.Monad.Eff (Eff(..))
-import Control.Reactive.Timer (Timer(..))
+import Control.Timer (Timer(..))
 import Data.Function
 import DOM (DOM(..))
 import Signal (constant, Signal(..), (~>), unwrap)

--- a/src/Signal/Time.purs
+++ b/src/Signal/Time.purs
@@ -9,7 +9,7 @@ module Signal.Time
 import Control.Monad.Eff (Eff(..))
 
 import Signal (constant, Signal(..))
-import Control.Reactive.Timer (Timer(..))
+import Control.Timer (Timer(..))
 
 type Time = Number
 

--- a/test/Signal.purs
+++ b/test/Signal.purs
@@ -4,7 +4,7 @@ module Test.Signal
   ) where
 
 import Control.Monad.Eff.Ref
-import Control.Reactive.Timer(Timer(..))
+import Control.Timer(Timer(..))
 import Data.Function
 import Signal
 import Test.Unit


### PR DESCRIPTION
They aren't tagging releases so when their API shifts, you end up
getting the latest. They changed their namespace. Note that you should
also merge a similar PR I made for purescript-test-unit, as that may
obstruct the building of this library.
