### PR TITLE
Add `debounce` function.

### DIFF
--- a/src/Signal.purs
+++ b/src/Signal.purs
@@ -24,7 +24,7 @@ module Signal
   ) where
 
 import Control.Monad.Eff (Eff())
-import Prelude ((<$>), flip, Unit(), class Eq, class Semigroup, class Functor, class Applicative, class Apply, map, apply)
+import Prelude
 import Data.Foldable (foldl, class Foldable)
 import Data.Maybe (Maybe(..), fromMaybe, isJust)
 


### PR DESCRIPTION
I also added `whenEqual` and `whenChangeTo` to support the `debounce` function.  They seemed generic enough to export and exist in Elm's Signal library, so I added them.  If you'd prefer they could just be nested inside `debounce`.

I'd also like feedback on the tests.  It's a little more verbose but it allows more detailed control of when events enter the channel.  I'm also a little confused about the existing `expectFn` helper, because the `whenEqual` and `whenChangeTo` tests seem to still pass if I add or remove a few things to the result array, but only more `3`s.  I don't quite understand it.