### PR TITLE
Fixed test suit to work with psc-0.9.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,9 +14,9 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "purescript-functions": "~0.1.0",
-    "purescript-test-unit": "~4.1.0",
-    "purescript-lists": "~0.7.10",
-    "purescript-console": "^0.1.1"
+    "purescript-functions": "~1.0.0",
+    "purescript-test-unit": "~7.0.0",
+    "purescript-lists": "~1.0.0",
+    "purescript-console": "^1.0.0"
   }
 }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,21 +1,23 @@
 module Test.Main where
 
+import Prelude
 import Control.Monad.Aff (Aff, later', forkAff)
 import Control.Monad.Aff.AVar (AVAR)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Class (liftEff)
+import Control.Monad.Eff.Console (CONSOLE)
 import Control.Monad.Eff.Ref (REF)
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Tuple (Tuple(..))
-import Prelude
 import Signal ((~>), runSignal, filterMap, filter, foldp, (~), (<~), dropRepeats, sampleOn, constant, mergeMany, flatten)
 import Signal.Channel (subscribe, send, channel, CHANNEL)
 import Signal.Time (since, delay, every, debounce)
 import Test.Signal (tick, expect, expectFn)
-import Test.Unit (test, timeout, runTest, TIMER)
+import Test.Unit (test, timeout, TIMER)
 import Test.Unit.Console (TESTOUTPUT)
+import Test.Unit.Main (runTest)
 
-main :: forall e. Eff (testOutput :: TESTOUTPUT, timer :: TIMER, ref :: REF, avar :: AVAR, channel :: CHANNEL | e) Unit
+main :: forall e. Eff (testOutput :: TESTOUTPUT, timer :: TIMER, ref :: REF, avar :: AVAR, channel :: CHANNEL, console :: CONSOLE | e) Unit
 main = runTest do
 
   test "subscribe to constant must yield once" do

--- a/test/Signal.purs
+++ b/test/Signal.purs
@@ -5,30 +5,31 @@ module Test.Signal
   ) where
 
 import Control.Monad.Aff (makeAff)
+import Control.Monad.Aff.AVar (AVAR)
 import Control.Monad.Eff.Exception (error)
 import Control.Monad.Eff.Ref (REF, writeRef, readRef, newRef)
-import Data.Function (Fn4, runFn4)
-import Data.List (List(..), toList, fromList)
-import Prelude (class Show, class Eq, bind, ($), show, (++), (/=), unit)
+import Data.Function.Uncurried (Fn4, runFn4)
+import Data.List (List(..), fromFoldable, toUnfoldable)
+import Prelude (class Show, class Eq, bind, ($), show, (<>), (/=), unit)
 import Signal (Signal, constant, (~>), runSignal)
-import Test.Unit (Assertion, timeout)
+import Test.Unit (Test, timeout, TIMER)
 
-expectFn :: forall e a. (Eq a, Show a) => Signal a -> Array a -> Assertion (ref :: REF | e)
+expectFn :: forall e a. (Eq a, Show a) => Signal a -> Array a -> Test (ref :: REF | e)
 expectFn sig vals = makeAff \fail win -> do
   remaining <- newRef vals
   let getNext val = do
         nextValArray <- readRef remaining
-        let nextVals = toList nextValArray
+        let nextVals = fromFoldable nextValArray
         case nextVals of
           Cons x xs -> do
-            if x /= val then fail $ error $ "expected " ++ show x ++ " but got " ++ show val
+            if x /= val then fail $ error $ "expected " <> show x <> " but got " <> show val
               else case xs of
                 Nil -> win unit
-                _ -> writeRef remaining (fromList xs)
+                _ -> writeRef remaining (toUnfoldable xs)
           Nil -> fail $ error "unexpected emptiness"
   runSignal $ sig ~> getNext
 
-expect :: forall e a. (Eq a, Show a) => Int -> Signal a -> Array a -> Assertion (ref :: REF | e)
+expect :: forall e a. (Eq a, Show a) => Int -> Signal a -> Array a -> Test (ref :: REF, timer :: TIMER, avar :: AVAR | e)
 expect time sig vals = timeout time $ expectFn sig vals
 
 foreign import tickP :: forall a c. Fn4 (c -> Signal c) Int Int (Array a) (Signal a)


### PR DESCRIPTION
It compiles -tests fail, maybe you could have a look?

8 tests failed:

In "dropRepeats only yields when value is /= previous":
  expected 1 but got 3

In "zip with Tuple yields a tuple of both signals":
  expected (Tuple 1 1) but got (Tuple 3 3)

In "sum up values with foldp":
  expected 1 but got 15

In "filter values with filter":
  expected 0 but got 4

In "filter Maybe values with filterMap":
  expected 0 but got 4

In "flatten flattens values":
  expected 1 but got 7

In "delayed signal yields same values":
  expected 1 but got 5

In "since yields true only once for multiple yields, then false":
  test timed out after 25ms