### PR TITLE
upgrade to purescript 0.11

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,19 +6,19 @@
     "url": "git://github.com/bodil/purescript-signal.git"
   },
   "dependencies": {
-    "purescript-dom": "^3.0.0",
-    "purescript-prelude": "^2.1.0",
-    "purescript-foldable-traversable": "^2.0.0",
-    "purescript-maybe": "^2.0.0",
-    "purescript-js-timers": "^2.0.0",
-    "purescript-monoid": "^2.2.0"
+    "purescript-dom": "^4.0.0",
+    "purescript-prelude": "^3.0.0",
+    "purescript-foldable-traversable": "^3.0.0",
+    "purescript-maybe": "^3.0.0",
+    "purescript-js-timers": "^3.0.0",
+    "purescript-monoid": "^3.0.0"
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "purescript-refs": "^2.0.0",
-    "purescript-functions": "^2.0.0",
-    "purescript-test-unit": "^10.0.0",
-    "purescript-lists": "^3.0.0",
-    "purescript-console": "^2.0.0"
+    "purescript-refs": "^3.0.0",
+    "purescript-functions": "^3.0.0",
+    "purescript-test-unit": "git://github.com/dgendill/purescript-test-unit#2311b8907d256aba4421584f583534b947a3e454",
+    "purescript-lists": "^4.0.1",
+    "purescript-console": "^3.0.0"
   }
 }

--- a/src/Signal.purs
+++ b/src/Signal.purs
@@ -32,7 +32,7 @@ import Data.Foldable (fold, foldl, class Foldable)
 import Data.Maybe (Maybe(..), fromMaybe, isJust)
 import Data.Monoid (class Monoid, mempty)
 
-foreign import data Signal :: * -> *
+foreign import data Signal :: Type -> Type
 
 -- |Creates a signal with a constant value.
 foreign import constant :: forall a. a -> Signal a
@@ -48,7 +48,7 @@ foreign import merge :: forall a. (Signal a) -> (Signal a) -> (Signal a)
 -- |Merge all signals inside a `Foldable`, returning a `Maybe` which will
 -- |either contain the resulting signal, or `Nothing` if the `Foldable`
 -- |was empty.
-mergeMany :: forall f a. (Functor f, Foldable f) => f (Signal a) -> Maybe (Signal a)
+mergeMany :: forall f a. Functor f => Foldable f => f (Signal a) -> Maybe (Signal a)
 mergeMany sigs = foldl mergeMaybe Nothing (Just <$> sigs)
   where mergeMaybe a Nothing = a
         mergeMaybe Nothing a = a
@@ -98,7 +98,7 @@ foreign import flattenArray :: forall a. Signal (Array a) -> a -> Signal a
 
 -- |Turns a signal of collections of items into a signal of each item inside
 -- |each collection, in order.
-flatten :: forall a f. (Functor f, Foldable f) => Signal (f a) -> a -> Signal a
+flatten :: forall a f. Functor f => Foldable f => Signal (f a) -> a -> Signal a
 flatten sig = flattenArray (sig ~> map (\i -> [i]) >>> fold)
 
 instance functorSignal :: Functor Signal where

--- a/src/Signal/Channel.purs
+++ b/src/Signal/Channel.purs
@@ -6,13 +6,13 @@ module Signal.Channel
   , CHANNEL
   ) where
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Eff (Eff, kind Effect)
 import Prelude (Unit)
 
 import Signal (constant, Signal)
 
-foreign import data Channel :: * -> *
-foreign import data CHANNEL :: !
+foreign import data Channel :: Type -> Type
+foreign import data CHANNEL :: Effect
 
 foreign import channelP :: forall a c e. (c -> Signal c) -> a -> Eff (channel :: CHANNEL | e) (Channel a)
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,7 +1,8 @@
 module Test.Main where
 
 import Prelude
-import Control.Monad.Aff (Aff, later', forkAff)
+import Control.Monad.Aff (Aff, forkAff)
+import Control.Monad.Aff as Aff
 import Control.Monad.Aff.AVar (AVAR)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Class (liftEff)
@@ -9,6 +10,7 @@ import Control.Monad.Eff.Console (CONSOLE)
 import Control.Monad.Eff.Ref (REF)
 import Control.Monad.Eff.Timer (TIMER)
 import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Time.Duration (Milliseconds(..))
 import Data.Tuple (Tuple(..))
 import Signal ((~>), runSignal, filterMap, filter, foldp, (~), (<~), dropRepeats, sampleOn, constant, mergeMany, flatten)
 import Signal.Channel (subscribe, send, channel, CHANNEL)
@@ -78,16 +80,16 @@ main = runTest do
     let sig = debounce 10.0 $ subscribe chan
         send' = liftEff <<< send chan
 
-    forkAff $ expect 50 sig [0,2,4]
-    wait 20
+    _ <- forkAff $ expect 50 sig [0,2,4]
+    wait 20.0
     send' 1
-    wait 5
+    wait 5.0
     send' 2
-    wait 20
+    wait 20.0
     send' 3
-    wait 5
+    wait 5.0
     send' 4
-    wait 20
+    wait 20.0
 
-wait :: forall e. Int -> Aff e Unit
-wait t = later' t $ pure unit
+wait :: forall e. Number -> Aff e Unit
+wait t = Aff.delay (Milliseconds t)

--- a/test/Signal.purs
+++ b/test/Signal.purs
@@ -15,7 +15,7 @@ import Prelude (class Show, class Eq, bind, ($), show, (<>), (/=), unit)
 import Signal (Signal, constant, (~>), runSignal)
 import Test.Unit (Test, timeout)
 
-expectFn :: forall e a. (Eq a, Show a) => Signal a -> Array a -> Test (ref :: REF | e)
+expectFn :: forall e a. Eq a => Show a => Signal a -> Array a -> Test (ref :: REF | e)
 expectFn sig vals = makeAff \fail win -> do
   remaining <- newRef vals
   let getNext val = do
@@ -30,7 +30,7 @@ expectFn sig vals = makeAff \fail win -> do
           Nil -> fail $ error "unexpected emptiness"
   runSignal $ sig ~> getNext
 
-expect :: forall e a. (Eq a, Show a) => Int -> Signal a -> Array a -> Test (ref :: REF, timer :: TIMER, avar :: AVAR | e)
+expect :: forall e a. Eq a => Show a => Int -> Signal a -> Array a -> Test (ref :: REF, timer :: TIMER, avar :: AVAR | e)
 expect time sig vals = timeout time $ expectFn sig vals
 
 foreign import tickP :: forall a c. Fn4 (c -> Signal c) Int Int (Array a) (Signal a)


### PR DESCRIPTION
Upgrade to purescript 0.11 

purescript-test-unit is not yet released for 0.11 - using the code of https://github.com/bodil/purescript-test-unit/pull/26 for now