### PR TITLE
Map effectful functions over signals

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,9 @@
     "purescript-foldable-traversable": "^3.0.0",
     "purescript-maybe": "^3.0.0",
     "purescript-js-timers": "^3.0.0",
-    "purescript-monoid": "^3.0.0"
+    "purescript-monoid": "^3.0.0",
+    "purescript-eff": "^3.1.0",
+    "purescript-aff": "^4.0.0"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/src/Signal/Aff.js
+++ b/src/Signal/Aff.js
@@ -1,7 +1,7 @@
 // module Signal.Aff
 
-exports.signalAffP =
-  function signalAffP(runAff_) {
+exports.mapAffP =
+  function mapAffP(runAff_) {
     return function (mkChannel) {
       return function (sendEither) {
         return function (action) {

--- a/src/Signal/Aff.js
+++ b/src/Signal/Aff.js
@@ -1,0 +1,22 @@
+// module Signal.Aff
+
+exports.signalAffP =
+  function signalAffP(runAff_) {
+    return function (mkChannel) {
+      return function (sendEither) {
+        return function (action) {
+          return function () {
+            return function (sig) {
+              var chan = mkChannel();
+              var send = sendEither(chan);
+              var runAction = runAff_(send);
+              sig.subscribe(function (val) {
+                runAction(action(val))();
+              });
+              return chan;
+            };
+          };
+        };
+      };
+    };
+  };

--- a/src/Signal/Aff.purs
+++ b/src/Signal/Aff.purs
@@ -1,5 +1,5 @@
 module Signal.Aff
-  ( signalAff
+  ( mapAff
   ) where
 
 import Prelude
@@ -14,8 +14,8 @@ import Signal.Channel (CHANNEL, Channel, channel, send)
 
 -- | Apply an async effectful function to signal values and signal the results.
 -- The output signal is Nothing before the first value is processed.
-signalAff :: forall a b e. (a -> Aff e b) -> Eff (channel :: CHANNEL | e) (Signal a -> Signal (Maybe b))
-signalAff action = signalAffP runAff_ mkChannel sendEither action
+mapAff :: forall a b e. (a -> Aff e b) -> Eff (channel :: CHANNEL | e) (Signal a -> Signal (Maybe b))
+mapAff action = mapAffP runAff_ mkChannel sendEither action
 
 mkChannel :: forall b e. Eff (channel :: CHANNEL | e) (Channel (Maybe b))
 mkChannel = channel Nothing
@@ -23,7 +23,7 @@ mkChannel = channel Nothing
 sendEither :: forall b e. Channel (Maybe b) -> Either Error b -> Eff (channel :: CHANNEL | e) Unit
 sendEither chan = either (const $ pure unit) (Just >>> send chan)
 
-foreign import signalAffP :: forall a b e. ((Either Error b -> Eff e Unit) -> Aff e b -> Eff e Unit) -- runAff_
+foreign import mapAffP :: forall a b e. ((Either Error b -> Eff e Unit) -> Aff e b -> Eff e Unit) -- runAff_
                           -> Eff (channel :: CHANNEL | e) (Channel (Maybe b)) -- mkChannel
                           -> (Channel (Maybe b) -> Either Error b -> Eff (channel :: CHANNEL | e) Unit) -- sendEither
                           -> (a -> Aff e b)

--- a/src/Signal/Aff.purs
+++ b/src/Signal/Aff.purs
@@ -1,0 +1,30 @@
+module Signal.Aff
+  ( signalAff
+  ) where
+
+import Prelude
+
+import Control.Monad.Aff (Aff, runAff_)
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Exception (Error)
+import Data.Either (Either, either)
+import Data.Maybe (Maybe(..))
+import Signal (Signal)
+import Signal.Channel (CHANNEL, Channel, channel, send)
+
+-- | Apply an async effectful function to signal values and signal the results.
+-- The output signal is Nothing before the first value is processed.
+signalAff :: forall a b e. (a -> Aff e b) -> Eff (channel :: CHANNEL | e) (Signal a -> Signal (Maybe b))
+signalAff action = signalAffP runAff_ mkChannel sendEither action
+
+mkChannel :: forall b e. Eff (channel :: CHANNEL | e) (Channel (Maybe b))
+mkChannel = channel Nothing
+
+sendEither :: forall b e. Channel (Maybe b) -> Either Error b -> Eff (channel :: CHANNEL | e) Unit
+sendEither chan = either (const $ pure unit) (Just >>> send chan)
+
+foreign import signalAffP :: forall a b e. ((Either Error b -> Eff e Unit) -> Aff e b -> Eff e Unit) -- runAff_
+                          -> Eff (channel :: CHANNEL | e) (Channel (Maybe b)) -- mkChannel
+                          -> (Channel (Maybe b) -> Either Error b -> Eff (channel :: CHANNEL | e) Unit) -- sendEither
+                          -> (a -> Aff e b)
+                          -> Eff (channel :: CHANNEL | e) (Signal a -> Signal (Maybe b))

--- a/src/Signal/Eff.js
+++ b/src/Signal/Eff.js
@@ -1,7 +1,7 @@
 // module Signal.Eff
 
-exports.signalEffP =
-  function signalEffP(channel) {
+exports.mapEffP =
+  function mapEffP(channel) {
     return function (send) {
       return function (action) {
         return function () {

--- a/src/Signal/Eff.js
+++ b/src/Signal/Eff.js
@@ -1,0 +1,19 @@
+// module Signal.Eff
+
+exports.signalEffP =
+  function signalEffP(channel) {
+    return function (send) {
+      return function (action) {
+        return function () {
+          return function (sig) {
+            var initial = action(sig.get());
+            var chan = channel(initial)();
+            sig.subscribe(function (val) {
+              send(chan)(action(val)())();
+            });
+            return chan;
+          };
+        };
+      };
+    };
+  };

--- a/src/Signal/Eff.purs
+++ b/src/Signal/Eff.purs
@@ -1,0 +1,16 @@
+module Signal.Eff
+  ( signalEff
+  ) where
+
+import Prelude
+import Control.Monad.Eff (Eff)
+import Signal (Signal)
+import Signal.Channel (CHANNEL, Channel, channel, send)
+
+foreign import signalEffP :: forall a b e. (b -> Eff (channel :: CHANNEL | e) (Channel b)) -- channel
+                          -> (Channel b -> b -> Eff (channel :: CHANNEL | e) Unit) -- send
+                          -> (a -> Eff e b)
+                          -> Eff (channel :: CHANNEL | e) (Signal a -> Signal b)
+
+signalEff :: forall a b e. (a -> Eff e b) -> Eff (channel :: CHANNEL | e) (Signal a -> Signal b)
+signalEff = signalEffP channel send

--- a/src/Signal/Eff.purs
+++ b/src/Signal/Eff.purs
@@ -1,5 +1,5 @@
 module Signal.Eff
-  ( signalEff
+  ( mapEff
   ) where
 
 import Prelude
@@ -7,10 +7,11 @@ import Control.Monad.Eff (Eff)
 import Signal (Signal)
 import Signal.Channel (CHANNEL, Channel, channel, send)
 
-foreign import signalEffP :: forall a b e. (b -> Eff (channel :: CHANNEL | e) (Channel b)) -- channel
+-- | Apply an effectful function to signal values and signal the results.
+foreign import mapEffP :: forall a b e. (b -> Eff (channel :: CHANNEL | e) (Channel b)) -- channel
                           -> (Channel b -> b -> Eff (channel :: CHANNEL | e) Unit) -- send
                           -> (a -> Eff e b)
                           -> Eff (channel :: CHANNEL | e) (Signal a -> Signal b)
 
-signalEff :: forall a b e. (a -> Eff e b) -> Eff (channel :: CHANNEL | e) (Signal a -> Signal b)
-signalEff = signalEffP channel send
+mapEff :: forall a b e. (a -> Eff e b) -> Eff (channel :: CHANNEL | e) (Signal a -> Signal b)
+mapEff = mapEffP channel send

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -15,9 +15,9 @@ import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Time.Duration (Milliseconds(..))
 import Data.Tuple (Tuple(..))
 import Signal ((~>), runSignal, filterMap, filter, foldp, (~), (<~), dropRepeats, sampleOn, constant, mergeMany, flatten)
-import Signal.Aff (signalAff)
+import Signal.Aff (mapAff)
 import Signal.Channel (subscribe, send, channel, CHANNEL)
-import Signal.Eff (signalEff)
+import Signal.Eff (mapEff)
 import Signal.Time (since, delay, every, debounce)
 import Test.Signal (expect, expectFn, incAff, incEff, tick)
 import Test.Unit (test, timeout)
@@ -50,11 +50,11 @@ main = runAndExit $ runTestWith runTest do
     expect 50 (tick 1 1 [1, 2, 3] ~> \x -> x * 2) [2, 4, 6]
 
   test "map effectful function over signal" do
-    signalConverter <- liftEff $ signalEff incEff
+    signalConverter <- liftEff $ mapEff incEff
     expect 50 (signalConverter $ tick 1 1 [1, 2, 3]) [2, 3, 4]
 
   test "map asynchronous effect over signal" do
-    signalConverter <- liftEff $ signalAff incAff
+    signalConverter <- liftEff $ mapAff incAff
     expect 150 (signalConverter $ tick 1 1 [1, 2, 3]) [Nothing, Just 2, Just 3, Just 4]
 
   test "sampleOn samples values from sig2 when sig1 changes" do

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -15,10 +15,11 @@ import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Time.Duration (Milliseconds(..))
 import Data.Tuple (Tuple(..))
 import Signal ((~>), runSignal, filterMap, filter, foldp, (~), (<~), dropRepeats, sampleOn, constant, mergeMany, flatten)
+import Signal.Aff (signalAff)
 import Signal.Channel (subscribe, send, channel, CHANNEL)
 import Signal.Eff (signalEff)
 import Signal.Time (since, delay, every, debounce)
-import Test.Signal (expect, expectFn, incEff, tick)
+import Test.Signal (expect, expectFn, incAff, incEff, tick)
 import Test.Unit (test, timeout)
 import Test.Unit.Console (TESTOUTPUT)
 import Test.Unit.Main (exit, runTestWith)
@@ -51,6 +52,10 @@ main = runAndExit $ runTestWith runTest do
   test "map effectful function over signal" do
     signalConverter <- liftEff $ signalEff incEff
     expect 50 (signalConverter $ tick 1 1 [1, 2, 3]) [2, 3, 4]
+
+  test "map asynchronous effect over signal" do
+    signalConverter <- liftEff $ signalAff incAff
+    expect 150 (signalConverter $ tick 1 1 [1, 2, 3]) [Nothing, Just 2, Just 3, Just 4]
 
   test "sampleOn samples values from sig2 when sig1 changes" do
     expect 150 (sampleOn (every 40.0) $ tick 10 20 [1, 2, 3, 4, 5, 6]) [1, 3, 5, 6]

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -16,8 +16,9 @@ import Data.Time.Duration (Milliseconds(..))
 import Data.Tuple (Tuple(..))
 import Signal ((~>), runSignal, filterMap, filter, foldp, (~), (<~), dropRepeats, sampleOn, constant, mergeMany, flatten)
 import Signal.Channel (subscribe, send, channel, CHANNEL)
+import Signal.Eff (signalEff)
 import Signal.Time (since, delay, every, debounce)
-import Test.Signal (tick, expect, expectFn)
+import Test.Signal (expect, expectFn, incEff, tick)
 import Test.Unit (test, timeout)
 import Test.Unit.Console (TESTOUTPUT)
 import Test.Unit.Main (exit, runTestWith)
@@ -46,6 +47,10 @@ main = runAndExit $ runTestWith runTest do
 
   test "map function over signal" do
     expect 50 (tick 1 1 [1, 2, 3] ~> \x -> x * 2) [2, 4, 6]
+
+  test "map effectful function over signal" do
+    signalConverter <- liftEff $ signalEff incEff
+    expect 50 (signalConverter $ tick 1 1 [1, 2, 3]) [2, 3, 4]
 
   test "sampleOn samples values from sig2 when sig1 changes" do
     expect 150 (sampleOn (every 40.0) $ tick 10 20 [1, 2, 3, 4, 5, 6]) [1, 3, 5, 6]

--- a/test/Signal.js
+++ b/test/Signal.js
@@ -12,4 +12,8 @@ exports.tickP = function tickP(constant, initial, interval, values) {
     }, initial);
   }
   return out;
-}
+};
+
+exports.incEff = function (val) {
+  return function () { return val + 1; };
+};

--- a/test/Signal.js
+++ b/test/Signal.js
@@ -17,3 +17,15 @@ exports.tickP = function tickP(constant, initial, interval, values) {
 exports.incEff = function (val) {
   return function () { return val + 1; };
 };
+
+exports.incAffP = function (right) {
+  return function (val) {
+    return function (callback) {
+      return function () {
+        setTimeout(function () {
+          callback(right(val + 1))();
+        }, 0);
+      };
+    };
+  };
+};

--- a/test/Signal.purs
+++ b/test/Signal.purs
@@ -1,12 +1,14 @@
 module Test.Signal
   ( expect
   , expectFn
+  , incEff
   , tick
   ) where
 
 import Prelude
 import Control.Monad.Aff (makeAff, nonCanceler)
 import Control.Monad.Aff.AVar (AVAR)
+import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Exception (error)
 import Control.Monad.Eff.Ref (REF, writeRef, readRef, newRef)
 import Control.Monad.Eff.Timer (TIMER)
@@ -39,3 +41,5 @@ foreign import tickP :: forall a c. Fn4 (c -> Signal c) Int Int (Array a) (Signa
 
 tick :: forall a. Int -> Int -> Array a -> Signal a
 tick = runFn4 tickP constant
+
+foreign import incEff :: forall e. Int -> Eff e Int

--- a/test/Signal.purs
+++ b/test/Signal.purs
@@ -1,15 +1,16 @@
 module Test.Signal
   ( expect
   , expectFn
+  , incAff
   , incEff
   , tick
   ) where
 
 import Prelude
-import Control.Monad.Aff (makeAff, nonCanceler)
+import Control.Monad.Aff (Aff, Canceler, makeAff, nonCanceler)
 import Control.Monad.Aff.AVar (AVAR)
 import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Exception (error)
+import Control.Monad.Eff.Exception (Error, error)
 import Control.Monad.Eff.Ref (REF, writeRef, readRef, newRef)
 import Control.Monad.Eff.Timer (TIMER)
 import Data.Either (Either(..))
@@ -43,3 +44,8 @@ tick :: forall a. Int -> Int -> Array a -> Signal a
 tick = runFn4 tickP constant
 
 foreign import incEff :: forall e. Int -> Eff e Int
+
+foreign import incAffP :: forall e. (Int -> Either Error Int) -> Int -> (Either Error Int -> Eff e Unit) -> Eff e (Canceler e)
+
+incAff :: forall e. Int -> Aff e Int
+incAff val = makeAff (incAffP Right val)


### PR DESCRIPTION
It can be useful to apply effectful functions, including asynchronous, to signal values, for example, getting some data using AJAX based on a signal coming from a Flare UI and using the result in the rest of the interface.

This PR adds `mapEff` and `mapAff` that can be used to apply `Eff` and `Aff` actions to signals to produce new signals. The signatures are aligned for use in Flare which is the main motivation, see [liftSF](https://pursuit.purescript.org/packages/purescript-flare/4.0.0/docs/Flare#v:liftSF).