### PR TITLE
Get current value of a signal

### DIFF
--- a/src/Signal.js
+++ b/src/Signal.js
@@ -146,3 +146,9 @@ exports.flattenArray = function(sig) {
     return out;
   };
 };
+
+exports.get = function(sig) {
+  return function() {
+    return sig.get();
+  };
+};

--- a/src/Signal.purs
+++ b/src/Signal.purs
@@ -9,6 +9,7 @@ module Signal
   , dropRepeats'
   , runSignal
   , unwrap
+  , get
   , filter
   , filterMap
   , flatten
@@ -79,6 +80,9 @@ foreign import runSignal :: Signal (Effect Unit) -> Effect Unit
 -- |signal which will take each effect produced by the input signal, run it,
 -- |and yield its returned value.
 foreign import unwrap :: forall a . Signal (Effect a) -> Effect (Signal a)
+
+-- |Gets the current value of the signal.
+foreign import get :: forall a . Signal a -> Effect a
 
 -- |Takes a signal and filters out yielded values for which the provided
 -- |predicate function returns `false`.

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,15 +2,16 @@ module Test.Main where
 
 import Prelude
 
-import Data.Either (either)
+import Data.Either (Either(..), either)
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Time.Duration (Milliseconds(..))
 import Data.Tuple (Tuple(..))
 import Effect (Effect)
-import Effect.Aff (Aff, forkAff, runAff)
+import Effect.Aff (Aff, forkAff, makeAff, nonCanceler, runAff)
 import Effect.Aff as Aff
 import Effect.Class (liftEffect)
-import Signal ((~>), runSignal, filterMap, filter, foldp, (~), (<~), dropRepeats, sampleOn, constant, mergeMany, flatten)
+import Effect.Exception (error)
+import Signal ((~>), get, runSignal, filterMap, filter, foldp, (~), (<~), dropRepeats, sampleOn, constant, mergeMany, flatten)
 import Signal.Aff (mapAff)
 import Signal.Channel (subscribe, send, channel)
 import Signal.Effect (mapEffect)
@@ -105,6 +106,15 @@ main = runAndExit $ runTestWith runTest do
     wait 5.0
     send' 4
     wait 20.0
+
+  test "get gets the current value" do
+    let sig = constant "example"
+    makeAff $ \resolve -> do
+      val <- liftEffect $ get sig
+      if (val == "example")
+        then resolve $ Right unit
+        else resolve $ Left $ error ("Expected get sig to return \"example\" but got " <> val)
+      pure nonCanceler
 
 wait :: Number -> Aff Unit
 wait t = do


### PR DESCRIPTION
This is a replacement for #60 updated for Purescript 0.12. Fixes #58.