### PR TITLE
Remove primes from foreign modules exports

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "purescript-refs": "^4.1.0",
     "purescript-functions": "^4.0.0",
-    "purescript-test-unit": "^14.0.0",
+    "purescript-test-unit": "^15.0.0",
     "purescript-lists": "^5.0.0",
     "purescript-console": "^4.1.0"
   }

--- a/src/Signal.js
+++ b/src/Signal.js
@@ -85,7 +85,7 @@ exports.dropRepeats = function(eq) {
   };
 };
 
-exports["dropRepeats'"] = function(sig) {
+exports.dropRepeatsByStrictInequality = function(sig) {
   var val = sig.get();
   var out = make(val);
   sig.subscribe(function(newval) {

--- a/src/Signal.purs
+++ b/src/Signal.purs
@@ -70,7 +70,10 @@ foreign import dropRepeats :: forall a. (Eq a) => Signal a -> Signal a
 -- |Create a signal which only yields values which aren't equal to the previous
 -- |value of the input signal, using JavaScript's `!==` operator to determine
 -- |disequality.
-foreign import dropRepeats' :: forall a. (Signal a) -> (Signal a)
+foreign import dropRepeatsByStrictInequality :: forall a. (Signal a) -> (Signal a)
+
+dropRepeats' :: forall a. (Signal a) -> (Signal a)
+dropRepeats' = dropRepeatsByStrictInequality
 
 -- |Given a signal of effects with no return value, run each effect as it
 -- |comes in.


### PR DESCRIPTION
Primes in foreign modules exports will be deprecated in v0.14.0. See https://github.com/purescript/purescript/pull/3792.